### PR TITLE
Add syntax highlighting to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 Build
 =====
 
-Configure nginx like this
+Install the `openvcdiff` packages.
+Configure nginx like this:
 
-configure --add-module=/path/to/this/directory ...other..flags...
-
-also install the openvcdiff packages.
+```
+./configure --add-module=/path/to/sdch_module
+```
 
 Directives
 =========


### PR DESCRIPTION
Move the directive about installing `openvcdiff` before `./configure` command
